### PR TITLE
Fix bug with bookmark caused by the wrong offsets being stored in memory

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -118,8 +118,9 @@ function start()
 	div.style.left = div.style.bottom = '5px';
 	head.appendChild(div);
 
-	// Set CodeMirror cursor to same position as cursor was in TinyMCE:
+	// Set CodeMirror cursor and bookmark to same position as cursor was in TinyMCE:
 	var html = editor.getContent({source_view: true});
+	editor.selection.getBookmark();
 	html = html.replace(/<span\s+class="CmCaReT"([^>]*)>([^<]*)<\/span>/gm, String.fromCharCode(chr));
 	editor.dom.remove(editor.dom.select('.CmCaReT'));
 


### PR DESCRIPTION
Because of  `<span id="CmCaReT"></span>` being inserted, the bookmark endOffset and startOffset will be incorrect until the bookmark is updated. By doing editor.selection.getBookmark(), the bookmark will be updated, fixing all bugs related to the offset of the rng in tinymce trying to be set to an incorrect value.

https://github.com/christiaan/tinymce-codemirror/issues/2
