### PR TITLE
Set the default theme

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -37,6 +37,7 @@ function inArray(key, arr)
 		indentOnInit: userSettings.indentOnInit || false,
 		config: {// Default config
 			mode: 'htmlmixed',
+			theme: 'default',
 			lineNumbers: true,
 			lineWrapping: true,
 			indentUnit: 1,


### PR DESCRIPTION
Instructions didn't say to explicitly set a theme in the tinyMCE init. Now 'default' theme is used by default without error.
