### PR TITLE
Better defaults, per codeMirror

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -39,8 +39,9 @@ function inArray(key, arr)
 			mode: 'htmlmixed',
 			lineNumbers: true,
 			lineWrapping: true,
-			indentUnit: 1,
-			tabSize: 1,
+			indentUnit: 2,
+			tabSize: 2,
+			indentWithTabs: true,
 			matchBrackets: true,
 			styleActiveLine: true
 		},


### PR DESCRIPTION
I couldn't figure out why the vanilla install looked not so vanilla. This straightens it out a bit.
