### PR TITLE
Fixes a bug in bookmark/cursor

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -145,7 +145,7 @@ function start()
     // [FIX] #6 z-index issue with table panel and source code dialog
     //	editor.selection.getBookmark();
     
-	html = html.replace(/<span\s+class="CmCaReT"([^>]*)>([^<]*)<\/span>/gm, String.fromCharCode(chr));
+	html = html.replace(/<span\s+style="display: none;"\s+class="CmCaReT"([^>]*)>([^<]*)<\/span>/gm, String.fromCharCode(chr));
 	editor.dom.remove(editor.dom.select('.CmCaReT'));
     
     // Hide TinyMCE toolbar panels, [FIX] #6 z-index issue with table panel and source code dialog


### PR DESCRIPTION
Sometimes when you open the HTML source code you'll see:
`<span style="display: none;" class="CmCaReT">�</span>`
Edited line 148 adding the `style` attribute so `replace()` finds the string properly.
