### PR TITLE
Fixed span.CmCaReT bugs

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -16,7 +16,7 @@ tinymce.PluginManager.add('codemirror', function(editor, url) {
 		// Insert caret marker
 		editor.focus();
 		editor.selection.collapse(true);
-		editor.selection.setContent('<span class="CmCaReT" style="display:none">&#0;</span>');
+		editor.selection.setContent('<span style="display: none;" class="CmCaReT">&#x0;</span>');
 
         codemirrorWidth = 800;
         if (editor.settings.codemirror.width) {


### PR DESCRIPTION
• Fixed span.CmCaReT showing up in the code view
• Fixed span.CmCaReT not being removed after pressing OK
• Fixed empty [p] tags being added to the top of the content after pressing OK
