### PR TITLE
Add 'saveCursorPosition' option

### DIFF
--- a/plugins/codemirror/plugin.js
+++ b/plugins/codemirror/plugin.js
@@ -13,10 +13,14 @@ tinymce.PluginManager.requireLangPack('codemirror');
 tinymce.PluginManager.add('codemirror', function(editor, url) {
 
 	function showSourceEditor() {
-		// Insert caret marker
-		editor.focus();
-		editor.selection.collapse(true);
-		editor.selection.setContent('<span style="display: none;" class="CmCaReT">&#x0;</span>');
+        
+        editor.focus();
+        editor.selection.collapse(true);
+        
+        // Insert caret marker
+        if (editor.settings.codemirror.saveCursorPosition) {
+            editor.selection.setContent('<span style="display: none;" class="CmCaReT">&#x0;</span>');
+        }
 
         codemirrorWidth = 800;
         if (editor.settings.codemirror.width) {

--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -44,6 +44,7 @@ function inArray(key, arr)
 			tabSize: 2,
 			indentWithTabs: true,
 			matchBrackets: true,
+      saveCursorPosition: true,
 			styleActiveLine: true
 		},
 		jsFiles: [// Default JS files


### PR DESCRIPTION
I'm working on a project where we'd rather not have the cursor code show up ('<span style="display: none;" class="CmCaReT">&#x0;</span>').

I made some minor changes to make the cursor code optional.
