### PR TITLE
Make html and body tags height 100%

### DIFF
--- a/plugins/codemirror/source.html
+++ b/plugins/codemirror/source.html
@@ -245,6 +245,8 @@ function submit()
 
 </script>
 <style type="text/css">
+  
+html,body { height:100%; }
 body {
 	margin: 0;
 }


### PR DESCRIPTION
Otherwise the codemirror editor doesn't fill the iframe